### PR TITLE
Lock corner nodes

### DIFF
--- a/FlubberView Example/ViewController.swift
+++ b/FlubberView Example/ViewController.swift
@@ -169,7 +169,7 @@ class ViewController: UIViewController {
         }
 
         frequencySlider.callBack = { frequency in
-            self.flubberView.frequency = frequency
+            self.flubberView.frequency = frequency * 5.0
         }
 
         dampingSlider.callBack = { damping in

--- a/FlubberView Example/ViewController.swift
+++ b/FlubberView Example/ViewController.swift
@@ -15,10 +15,10 @@ class ViewController: UIViewController {
         let layer = CAShapeLayer()
         layer.fillColor = UIColor.yellow.cgColor
         return FlubberView(withDesiredSize: CGSize(width: 150, height: 150),
-                         shapeLayer: layer,
+                         shapeLayer: nil,
                          damping: 0.1,
                          frequency: 1.0,
-                         nodeDensity: .medium)
+                         nodeDensity: .low)
     }()
 
     var magnitudeSlider: Slider = Slider()

--- a/FlubberView Example/ViewController.swift
+++ b/FlubberView Example/ViewController.swift
@@ -15,10 +15,10 @@ class ViewController: UIViewController {
         let layer = CAShapeLayer()
         layer.fillColor = UIColor.yellow.cgColor
         return FlubberView(withDesiredSize: CGSize(width: 150, height: 150),
-                         shapeLayer: nil,
+                         shapeLayer: layer,
                          damping: 0.1,
                          frequency: 1.0,
-                         nodeDensity: .low)
+                         nodeDensity: .medium)
     }()
 
     var magnitudeSlider: Slider = Slider()

--- a/FlubberView/Flubber.swift
+++ b/FlubberView/Flubber.swift
@@ -57,6 +57,7 @@ protocol ElasticConfigurable: Initializable {
          shapeLayer: CAShapeLayer?,
          damping: CGFloat,
          frequency: CGFloat,
+         duration: TimeInterval,
          nodeDensity: NodeDensity)
 
 }

--- a/FlubberView/Flubber.swift
+++ b/FlubberView/Flubber.swift
@@ -35,6 +35,10 @@ protocol ElasticConfigurable: Initializable {
     /// within the FlubberView
     var frequency: CGFloat { get set }
 
+    /// The duration of the animation (view snaps back into place
+    /// after the duration has elapsed)
+    var duration: TimeInterval { get set }
+
     /// A CADisplayLink instance to handle redrawing the FlubberView
     /// at regular intervals
     var displayLink: CADisplayLink { get }

--- a/FlubberView/FlubberView.swift
+++ b/FlubberView/FlubberView.swift
@@ -27,7 +27,7 @@ public final class FlubberView: UIView {
     public var frequency: CGFloat = 0.0 {
         didSet { reset() }
     }
-    public var duration: TimeInterval = 2.0 {
+    public var duration: TimeInterval = 1.0 {
         didSet { reset() }
     }
     public var damping: CGFloat = 0.0 {
@@ -58,11 +58,13 @@ extension FlubberView: ElasticConfigurable {
                             shapeLayer: CAShapeLayer? = nil,
                             damping: CGFloat,
                             frequency: CGFloat,
+                            duration: TimeInterval = 1.0,
                             nodeDensity: NodeDensity = .medium) {
         self.init()
         self.damping = damping
         self.shapeLayer = shapeLayer
         self.frequency = frequency
+        self.duration = duration
         self.nodeDensity = nodeDensity
         frame.size = desiredSize
         compose()
@@ -123,7 +125,7 @@ public extension FlubberView {
                 attachBehaviors.setObject(anchor, forKey: v)
                 mainAnimator.addBehavior(anchor)
             }
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0, execute: {
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + duration, execute: {
                 let snap = UISnapBehavior(item: v, snapTo: initialPoint)
                 snap.damping = 0.0
                 self.attachBehaviors.setObject(snap, forKey: v)

--- a/FlubberView/FlubberView.swift
+++ b/FlubberView/FlubberView.swift
@@ -15,7 +15,7 @@ public final class FlubberView: UIView {
     public var magnitude: Magnitude = .medium
 
     /// Storage for the attachment behaviors belonging to individual subviews
-    var behaviors: NSMapTable<UIView, UISnapBehavior> = NSMapTable()
+    var behaviors: NSMapTable<UIView, UIAttachmentBehavior> = NSMapTable()
 
     /// Storage for the initial origin coordinates of each individual subview
     var nodeCenterCoordinates: NSMapTable<UIView, NSValue> = NSMapTable()
@@ -111,19 +111,19 @@ public extension FlubberView {
             let initialPoint = nodeCenterCoordinates.object(forKey: v)?.cgPointValue ??
                 CGPoint(x: v.frame.midX, y: v.frame.midY)
             let elasticity = magnitude.elasticity
-            let snapBehavior = UISnapBehavior(item: v, snapTo: initialPoint)
+            let bounceBehavior = UIAttachmentBehavior(item: v, attachedToAnchor: initialPoint)
 
-
-            snapBehavior.damping = damping
+            bounceBehavior.damping = damping
+            bounceBehavior.frequency = frequency
 
             let oldBehavior = behaviors.object(forKey: v)
-            behaviors.setObject(snapBehavior, forKey: v)
+            behaviors.setObject(bounceBehavior, forKey: v)
 
             if let behavior = oldBehavior {
                 mainAnimator.removeBehavior(behavior)
             }
 
-            mainAnimator.addBehavior(snapBehavior)
+            mainAnimator.addBehavior(bounceBehavior)
             v.center = CGPoint(x: v.center.x <~> elasticity, y: v.center.y <~> elasticity)
             mainAnimator.updateItem(usingCurrentState: v)
         }
@@ -316,14 +316,12 @@ private extension FlubberView {
                     let attach: UIAttachmentBehavior = UIAttachmentBehavior(item: view,
                                                                             attachedTo: nextView)
 
-                    attach.damping = 0
-                    attach.frequency = 1
+                    attach.damping = damping
+                    attach.frequency = frequency
 
                     mainAnimator.addBehavior(attach)
 
                     let bh: UIDynamicItemBehavior = UIDynamicItemBehavior(items: [view])
-                    bh.resistance = 0
-                    bh.elasticity = 1
 
                     mainAnimator.addBehavior(bh)
                 }

--- a/FlubberView/FlubberView.swift
+++ b/FlubberView/FlubberView.swift
@@ -15,7 +15,7 @@ public final class FlubberView: UIView {
     public var magnitude: Magnitude = .medium
 
     /// Storage for the attachment behaviors belonging to individual subviews
-    var behaviors: NSMapTable<UIView, UIAttachmentBehavior> = NSMapTable()
+    var attachBehaviors: NSMapTable<UIView, UIAttachmentBehavior> = NSMapTable()
 
     /// Storage for the initial origin coordinates of each individual subview
     var nodeCenterCoordinates: NSMapTable<UIView, NSValue> = NSMapTable()
@@ -107,17 +107,17 @@ public extension FlubberView {
     /// - parameter magnitude: controls the distance that each node
     /// will move during the animation
     func animate() {
-        for v in subviews {
-            let initialPoint = nodeCenterCoordinates.object(forKey: v)?.cgPointValue ??
-                CGPoint(x: v.frame.midX, y: v.frame.midY)
-            let elasticity = magnitude.elasticity
-            let bounceBehavior = UIAttachmentBehavior(item: v, attachedToAnchor: initialPoint)
+        let v = subviews[4]
+                let initialPoint = nodeCenterCoordinates.object(forKey: v)?.cgPointValue ??
+                    CGPoint(x: v.frame.midX, y: v.frame.midY)
+                                let elasticity = magnitude.elasticity
+                                let bounceBehavior = UIAttachmentBehavior(item: v, attachedToAnchor: initialPoint)
 
             bounceBehavior.damping = damping
             bounceBehavior.frequency = frequency
 
-            let oldBehavior = behaviors.object(forKey: v)
-            behaviors.setObject(bounceBehavior, forKey: v)
+            let oldBehavior = attachBehaviors.object(forKey: v)
+            attachBehaviors.setObject(bounceBehavior, forKey: v)
 
             if let behavior = oldBehavior {
                 mainAnimator.removeBehavior(behavior)
@@ -126,7 +126,6 @@ public extension FlubberView {
             mainAnimator.addBehavior(bounceBehavior)
             v.center = CGPoint(x: v.center.x <~> elasticity, y: v.center.y <~> elasticity)
             mainAnimator.updateItem(usingCurrentState: v)
-        }
     }
 
 }
@@ -309,6 +308,7 @@ private extension FlubberView {
 
         for i in 0..<subviews.count {
             let view = subviews[i]
+            view.backgroundColor = .green
 
             for nextView in subviews {
                 if (view.center.x - nextView.center.x == distanceBetweenNodes) ||

--- a/FlubberView/FlubberView.swift
+++ b/FlubberView/FlubberView.swift
@@ -15,7 +15,7 @@ public final class FlubberView: UIView {
     public var magnitude: Magnitude = .medium
 
     /// Storage for the attachment behaviors belonging to individual subviews
-    var attachBehaviors: NSMapTable<UIView, UIAttachmentBehavior> = NSMapTable()
+    var attachBehaviors: NSMapTable<UIView, UIDynamicBehavior> = NSMapTable()
 
     /// Storage for the initial origin coordinates of each individual subview
     var nodeCenterCoordinates: NSMapTable<UIView, NSValue> = NSMapTable()
@@ -25,14 +25,13 @@ public final class FlubberView: UIView {
     var displayLink: CADisplayLink = CADisplayLink()
     var shapeLayer: CAShapeLayer?
     public var frequency: CGFloat = 0.0 {
-        didSet {
-            reset()
-        }
+        didSet { reset() }
+    }
+    public var duration: TimeInterval = 2.0 {
+        didSet { reset() }
     }
     public var damping: CGFloat = 0.0 {
-        didSet {
-            reset()
-        }
+        didSet { reset() }
     }
     var nodeDensity: NodeDensity = .medium {
         didSet {
@@ -78,14 +77,14 @@ public extension FlubberView {
         case low, medium, high
 
         /// The distance each node will move while animating
-        var elasticity: CGFloat {
-            let elasticity: CGFloat
+        var impulse: UInt32 {
+            let impulse: UInt32
             switch self {
-            case .low: elasticity = 4.0
-            case .medium: elasticity = 16.0
-            case .high: elasticity = 64.0
+            case .low: impulse = 2
+            case .medium: impulse = 3
+            case .high: impulse = 4
             }
-            return elasticity
+            return impulse
         }
 
     }
@@ -107,25 +106,30 @@ public extension FlubberView {
     /// - parameter magnitude: controls the distance that each node
     /// will move during the animation
     func animate() {
-        let v = subviews[4]
-                let initialPoint = nodeCenterCoordinates.object(forKey: v)?.cgPointValue ??
+        for v in subviews {
+            let initialPoint = nodeCenterCoordinates.object(forKey: v)?.cgPointValue ??
                     CGPoint(x: v.frame.midX, y: v.frame.midY)
-                                let elasticity = magnitude.elasticity
-                                let bounceBehavior = UIAttachmentBehavior(item: v, attachedToAnchor: initialPoint)
-
-            bounceBehavior.damping = damping
-            bounceBehavior.frequency = frequency
-
             let oldBehavior = attachBehaviors.object(forKey: v)
-            attachBehaviors.setObject(bounceBehavior, forKey: v)
-
             if let behavior = oldBehavior {
                 mainAnimator.removeBehavior(behavior)
             }
-
-            mainAnimator.addBehavior(bounceBehavior)
-            v.center = CGPoint(x: v.center.x <~> elasticity, y: v.center.y <~> elasticity)
-            mainAnimator.updateItem(usingCurrentState: v)
+            if !cornerNodeIndices.contains(v.tag) {
+                let push = force(for: v)
+                attachBehaviors.setObject(push, forKey: v)
+                mainAnimator.addBehavior(push)
+            } else {
+                let anchor = UIDynamicItemBehavior(items:[v])
+                anchor.density = 1000
+                attachBehaviors.setObject(anchor, forKey: v)
+                mainAnimator.addBehavior(anchor)
+            }
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0, execute: {
+                let snap = UISnapBehavior(item: v, snapTo: initialPoint)
+                snap.damping = 0.0
+                self.attachBehaviors.setObject(snap, forKey: v)
+                self.mainAnimator.addBehavior(snap)
+            })
+        }
     }
 
 }
@@ -256,6 +260,19 @@ private extension FlubberView {
     }
 
 
+    /// Generates a UIPushBehavior for a given UIView.
+    ///
+    /// - Parameter view: the view to which the push behavior will be applied.
+    /// - Returns: a UIPushBehavior.
+    func force(for view: UIView) -> UIPushBehavior {
+        let force = UIPushBehavior(items: [view], mode: .instantaneous)
+        let randX = (CGFloat(arc4random_uniform(magnitude.impulse)) / 50)
+        let randY = (CGFloat(arc4random_uniform(magnitude.impulse)) / 50)
+        force.pushDirection = CGVector(dx: 0 <~> randX, dy: 0 <~> randY)
+
+        return force
+    }
+
     /// Adds shapeLayer as a sublayer if not nil
     func setupMainLayer() {
         guard let shapeLayer = shapeLayer else {
@@ -308,7 +325,6 @@ private extension FlubberView {
 
         for i in 0..<subviews.count {
             let view = subviews[i]
-            view.backgroundColor = .green
 
             for nextView in subviews {
                 if (view.center.x - nextView.center.x == distanceBetweenNodes) ||


### PR DESCRIPTION
Bit of a dramatic rethinking, building off @ateliercw 's idea of locking certain nodes while animating others

- Corner nodes are locked in place
- All other nodes are folded into a `UIPushBehavior` which is added immediately to `mainAnimator`
- After a time interval specified by a new constructor parameter (`duration`, defaults to `1.0`), a `UISnapBehavior is applied to each subview, snapping it back into place